### PR TITLE
fix: Clear and print progress when tqdm is not available

### DIFF
--- a/ffmpeg_progress_yield/__main__.py
+++ b/ffmpeg_progress_yield/__main__.py
@@ -50,7 +50,7 @@ def main() -> None:
                 pbar.update(progress - pbar.n)
     except ImportError:
         for progress in ff.run_command_with_progress():
-            print(f"{progress}/100", end="\r")
+            print(f"\x1b[K{progress}/100", end="\r")
         print()
 
     if platform.system() == "Windows":


### PR DESCRIPTION
This relates two printing sequence:

(1) Print one decimal place after printing two decimal places

0.74/100 -> 0.8/100 (1 less character)

(2) Print 100/100 after printing decimal progress

99.74/100 -> 100/100 (2 less characters)

99.8/100 -> 100/100 (1 less character)

So clear the line first, and print progress, showing for a moment, and then repeat, finally a newline. :)